### PR TITLE
Fix: Correct Neo4j username env var and add validation

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -83,9 +83,15 @@ def get_db() -> Connection:
 # neo4J
 
 NEO4J_URI = os.getenv("NEO4J_URI")
-NEO4J_USER = os.getenv("NEO4J_USER")
+NEO4J_USERNAME = os.getenv("NEO4J_USERNAME")  # Corrected variable name
 NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
 
+if not NEO4J_URI:
+    raise ValueError("Missing NEO4J_URI environment variable. Cannot connect to Neo4j.")
+if not NEO4J_USERNAME:
+    raise ValueError("Missing NEO4J_USERNAME environment variable. Cannot connect to Neo4j.")
+if not NEO4J_PASSWORD:
+    raise ValueError("Missing NEO4J_PASSWORD environment variable. Cannot connect to Neo4j.")
 
 # This class will manage the driver instance
 class GraphDatabaseManager:
@@ -94,7 +100,7 @@ class GraphDatabaseManager:
 
     def connect(self):
         """Establishes the connection to the Neo4j database."""
-        self.driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+        self.driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))
 
     def close(self):
         """Closes the connection."""


### PR DESCRIPTION
- Changed NEO4J_USER to NEO4J_USERNAME in api/database.py to align with standard usage and db_connection_test.py.
- Added a startup check to ensure NEO4J_URI, NEO4J_USERNAME, and NEO4J_PASSWORD are set, raising an error if not.

This addresses a potential cause for 500 errors on graph endpoints due to incorrect or missing Neo4j authentication details.