### PR TITLE
Fix: Expose FastAPI app globally for Render deployment

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -48,4 +48,4 @@ def create_app():
 # For testing, the factory will be called by the test fixture.
 # For production, uvicorn can be told to use the factory: uvicorn api.main:create_app --factory
 # If a global 'app' is needed for some deployment scripts not using --factory:
-# app = create_app()
+app = create_app()


### PR DESCRIPTION
Uncommented `app = create_app()` in `api/main.py`. This makes the FastAPI application instance available globally, addressing an `AttributeError` during Render deployments where the ASGI server expects an `app` object at the module level by default, rather than using the `--factory` option.