### PR TITLE
Fix: Pin passlib to >=1.7.4 for bcrypt compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psycopg2-binary
 neo4j
 
 # Security and Authentication
-passlib[bcrypt]
+passlib[bcrypt]>=1.7.4
 python-jose[cryptography]
 python-dotenv
 jwcrypto


### PR DESCRIPTION
This change addresses an AttributeError that occurs when passlib < 1.7.4 is used with bcrypt >= 4.1.0, due to changes in how bcrypt exposes its version.

Pinning passlib to version 1.7.4 or greater resolves this issue. This is expected to also resolve the downstream "Issuer key not found" error, which was likely caused by the initial bcrypt/passlib loading failure disrupting cryptographic operations.