### PR TITLE
I am refactoring the `parse_goal_into_subtasks` function to create `Q…

### DIFF
--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -1,18 +1,19 @@
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 from typing import List
-from neo4j import Driver
+from neo4j import Session as Neo4jSession # Changed Driver to Session
 from ..ai.parser import goal_parser_chain
-from ..ai.schemas import ParsedGoal, SkillLevel
-from ..ai.skill_extractor import skill_extractor_chain
-from ..ai.skill_matcher import find_skill_match
+# ParsedGoal is no longer the direct response_model, but its structure is used
+from ..ai.schemas import ParsedGoal, SubTask
 
 # Database Imports
-from ..database import get_graph_db_driver
+from ..database import get_graph_db_session # Changed to get_graph_db_session
+from .. import graph_crud # Added graph_crud import
+from .. import schemas # Added schemas import for response_model
 
 # Security Imports
-from .auth import get_current_user
-from ..schemas import User
+# from .auth import get_current_user # Not used in this specific function currently
+# from ..schemas import User # Not used in this specific function currently
 
 router = APIRouter()
 
@@ -21,16 +22,36 @@ class GoalRequest(BaseModel):
     goal: str
 
 
-@router.post("/goals/parse", response_model=ParsedGoal, tags=["AI"])
-async def parse_goal_into_subtasks(request: GoalRequest):
+@router.post("/goals/parse", response_model=List[schemas.Quest], tags=["AI"]) # Changed response_model
+async def parse_goal_into_subtasks(
+    request: GoalRequest,
+    db: Neo4jSession = Depends(get_graph_db_session) # Added db session dependency
+):
     """
-    Accepts a high-level goal and uses an LLM to break it down into
-    a structured list of sub-tasks.
+    Accepts a high-level goal, uses an LLM to break it down into
+    a structured list of sub-tasks, creates a Quest node for each sub-task,
+    and returns the list of created Quests.
     """
     try:
         # Invoke the LangChain chain with the user's goal
-        parsed_result = await goal_parser_chain.ainvoke({"goal": request.goal})
-        return parsed_result
+        # parsed_result will be of type ParsedGoal
+        parsed_result: ParsedGoal = await goal_parser_chain.ainvoke({"goal": request.goal})
+
+        created_quests: List[schemas.Quest] = []
+        if parsed_result and parsed_result.sub_tasks:
+            for sub_task in parsed_result.sub_tasks:
+                quest_data = {
+                    "name": sub_task.title, # Using title from SubTask
+                    "description": sub_task.description # Using description from SubTask
+                }
+                # Create a Quest node in the graph for each sub-task
+                # graph_crud.create_quest returns a Neo4j Node object
+                new_quest_node = db.write_transaction(graph_crud.create_quest, quest_data)
+                # FastAPI will automatically convert the Node to schemas.Quest
+                # due to model_config = {"from_attributes": True} in schemas.Quest
+                created_quests.append(new_quest_node)
+
+        return created_quests
     except Exception as e:
         # Handle potential parsing errors or API failures
-        raise HTTPException(status_code=500, detail=f"Failed to parse goal: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to parse goal and create quests: {str(e)}")


### PR DESCRIPTION
…uest` nodes.

I will modify the `parse_goal_into_subtasks` endpoint in `api/routers/goals.py`. Instead of returning the direct output from the LLM, this change processes the tasks generated by the LLM.

For each task:
- A new `Quest` node will be created in the Neo4j database.
- The task's title and description will be used as the name and description for the `Quest`.

The endpoint will now return a list of these newly created `Quest` objects. The `response_model` will be updated to `List[schemas.Quest]`. Database session management will be updated.