### PR TITLE
feat: Store VC receipt after issuance

### DIFF
--- a/api/routers/accomplishments.py
+++ b/api/routers/accomplishments.py
@@ -221,6 +221,18 @@ def issue_accomplishment_credential(
         "vc": vc_payload,
     }
 
+    # NEW STEP: Store a receipt of the VC in the graph *before* returning
+    vc_receipt = {
+        "id": vc_payload["id"],
+        "issuanceDate": vc_payload["issuanceDate"]
+    }
+    with driver.session() as session:
+        session.write_transaction(
+            graph_crud.store_vc_receipt,
+            accomplishment_id,
+            vc_receipt
+        )
+
     # 5. Sign the JWT with the private key
     signed_vc_jwt = jwt.encode(
         claims=jwt_claims,


### PR DESCRIPTION
I modified the `issue_accomplishment_credential` endpoint to store a receipt of the Verifiable Credential in the graph database after successful JWT generation and before signing.

This involves calling the `store_vc_receipt` graph CRUD function with the VC's ID and issuance date.