### PR TITLE
Refactor: Use auth token for user ID in accomplishment processing

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -77,15 +77,19 @@ class Quest(QuestBase):
 
 
 class AccomplishmentCreate(BaseModel):
-    user_email: str # Added user_email as it's needed for creating an accomplishment
     name: str
     description: str
     proof_url: Optional[str] = None
     quest_id: Optional[uuid.UUID] = None
 
 
-class Accomplishment(AccomplishmentCreate):
+class Accomplishment(BaseModel):
     id: uuid.UUID
+    user_email: str  # This field is needed for output
+    name: str
+    description: str
+    proof_url: Optional[str] = None
+    quest_id: Optional[uuid.UUID] = None
     timestamp: datetime
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
- Removed `user_email` from `AccomplishmentCreate` schema.
- Updated `Accomplishment` output schema to include `user_email`.
- Simplified `graph_crud.create_accomplishment` to take `user_email` directly and use a dict for accomplishment data.
- Modified `process_accomplishment` endpoint in `routers/accomplishments.py`:
  - User identity is now solely from `current_user.email` (auth token).
  - Removed redundant user existence check.
  - Updated calls to `create_accomplishment` and `AccomplishmentSchema` validation to align with new data flow.