### PR TITLE
Add basic frontend and static routing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -31,20 +31,31 @@ def create_app():
         version="0.1.0",
     )
 
+    # Include routers with their default prefixes (used by tests)
     app.include_router(skills.router, prefix="/skills")
     app.include_router(users.router)
     app.include_router(auth.router)
     app.include_router(goals.router)
     app.include_router(qa.router)
     app.include_router(accomplishments.router)
-    app.include_router(quests.router) # Added quests router
+    app.include_router(quests.router)  # Added quests router
+
+    # Also expose the same routes under /api for the frontend
+    api_prefix = "/api"
+    app.include_router(skills.router, prefix=f"{api_prefix}/skills")
+    app.include_router(users.router, prefix=api_prefix)
+    app.include_router(auth.router, prefix=api_prefix)
+    app.include_router(goals.router, prefix=api_prefix)
+    app.include_router(qa.router, prefix=api_prefix)
+    app.include_router(accomplishments.router, prefix=api_prefix)
+    app.include_router(quests.router, prefix=api_prefix)
 
     # Mount the frontend directory to serve static files
-    app.mount("/", StaticFiles(directory="frontend"), name="frontend")
+    app.mount("/static", StaticFiles(directory="frontend"), name="static")
 
-    @app.get("/", tags=["Root"])
+    @app.get("/", include_in_schema=False)
     async def read_root():
-        return FileResponse('frontend/index.html')
+        return FileResponse("frontend/index.html")
 
     return app
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,13 +3,41 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SkillForge</title>
+    <title>SkillForge MVP</title>
+    <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <h1>SkillForge</h1>
-    <textarea id="goal-input" placeholder="Enter your learning goal"></textarea>
-    <button id="submit-goal">Submit</button>
-    <div id="quest-display"></div>
-    <script src="script.js"></script>
+    <h1>SkillForge MVP</h1>
+
+    <section id="user-section">
+        <h2>User Management</h2>
+        <input id="email" type="email" placeholder="Email">
+        <input id="password" type="password" placeholder="Password">
+        <button id="register-btn">Create User</button>
+        <button id="login-btn">Log In</button>
+        <pre id="user-result"></pre>
+    </section>
+
+    <section id="goal-section">
+        <h2>Goal Parsing</h2>
+        <textarea id="goal" placeholder="Enter your goal"></textarea>
+        <button id="submit-goal">Submit Goal</button>
+        <div id="quest-display"></div>
+    </section>
+
+    <section id="accomplishment-section">
+        <h2>Active Quest</h2>
+        <div id="active-quest"></div>
+        <textarea id="accomplishment" placeholder="Describe your accomplishment"></textarea>
+        <button id="submit-accomplishment">Submit Accomplishment</button>
+        <pre id="accomplishment-result"></pre>
+    </section>
+
+    <section id="vc-section">
+        <h2>Verifiable Credential</h2>
+        <pre id="vc-display"></pre>
+    </section>
+
+    <script src="/static/script.js"></script>
 </body>
 </html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,19 +1,73 @@
-document.getElementById('submit-goal').addEventListener('click', () => {
-    const goal = document.getElementById('goal-input').value;
-    fetch('/goals/parse', {
+let token = null;
+let activeQuest = null;
+
+async function createUser() {
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+    const resp = await fetch('/api/users/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, name: email })
+    });
+    const data = await resp.json();
+    document.getElementById('user-result').textContent = JSON.stringify(data, null, 2);
+}
+
+async function login() {
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+    const params = new URLSearchParams();
+    params.append('username', email);
+    params.append('password', password);
+    const resp = await fetch('/api/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params
+    });
+    const data = await resp.json();
+    token = data.access_token;
+    document.getElementById('user-result').textContent = 'Logged in';
+}
+
+async function submitGoal() {
+    const goalText = document.getElementById('goal').value;
+    const resp = await fetch('/api/goals/parse', {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
         },
-        body: JSON.stringify({ text: goal })
-    })
-    .then(response => response.json())
-    .then(data => {
-        const questDisplay = document.getElementById('quest-display');
-        questDisplay.innerHTML = `
-            <h2>${data.name}</h2>
-            <p>${data.description}</p>
-        `;
-    })
-    .catch(error => console.error('Error:', error));
-});
+        body: JSON.stringify({ goal: goalText })
+    });
+    const data = await resp.json();
+    activeQuest = data;
+    document.getElementById('quest-display').textContent = `${data.name}: ${data.description}`;
+    document.getElementById('active-quest').textContent = `${data.name}: ${data.description}`;
+}
+
+async function submitAccomplishment() {
+    if (!activeQuest) return;
+    const description = document.getElementById('accomplishment').value;
+    const resp = await fetch('/api/accomplishments/process', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ name: 'Accomplishment', description, quest_id: activeQuest.id })
+    });
+    const data = await resp.json();
+    document.getElementById('accomplishment-result').textContent = JSON.stringify(data, null, 2);
+    const accId = data.accomplishment.id;
+    const vcResp = await fetch(`/api/accomplishments/${accId}/issue-credential`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const vcData = await vcResp.json();
+    document.getElementById('vc-display').textContent = vcData.verifiable_credential_jwt;
+}
+
+document.getElementById('register-btn').addEventListener('click', createUser);
+document.getElementById('login-btn').addEventListener('click', login);
+document.getElementById('submit-goal').addEventListener('click', submitGoal);
+document.getElementById('submit-accomplishment').addEventListener('click', submitAccomplishment);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,19 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+}
+section {
+    margin-bottom: 2rem;
+    padding: 1rem;
+    border: 1px solid #ccc;
+}
+textarea {
+    width: 100%;
+    height: 60px;
+    margin-bottom: 0.5rem;
+}
+pre {
+    background: #f5f5f5;
+    padding: 0.5rem;
+    overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- create simple HTML interface with user/login, goal, quest, accomplishment and credential sections
- add minimal styles and client-side logic to interact with API
- serve frontend from FastAPI with `/static` and root HTML
- expose API routes under `/api` alongside existing paths

## Testing
- `pytest -q` *(fails: neo4j service unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687a62d5736c832a89faf1e00afa9cb5