### PR TITLE
Render quest list from parsed goal

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -111,3 +111,8 @@ class Accomplishment(AccomplishmentCreate):
         if isinstance(value, Neo4jDateTime):
             return value.to_native()
         return value
+
+
+class GoalAndQuest(BaseModel):
+    goal: Goal
+    quest: Quest

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,7 @@
         <textarea id="goal" placeholder="Enter your goal"></textarea>
         <button id="submit-goal">Submit Goal</button>
         <div id="quest-display"></div>
+        <ul id="quest-list"></ul>
     </section>
 
     <section id="accomplishment-section">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -17,3 +17,17 @@ pre {
     padding: 0.5rem;
     overflow-x: auto;
 }
+
+/* Quest list styling */
+#quest-list li.completed {
+    text-decoration: line-through;
+    color: gray;
+}
+
+#quest-list li.active {
+    font-weight: bold;
+}
+
+#quest-list li.future {
+    color: #555;
+}

--- a/tests/test_goals_parse_api.py
+++ b/tests/test_goals_parse_api.py
@@ -1,0 +1,62 @@
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+from api.schemas import User
+from api.ai.schemas import ParsedGoal, SubTask
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_dependencies(mocker):
+    # Mock graph db session
+    mock_session = mocker.MagicMock(name="MOCK_SESSION")
+    goal_node = {
+        "id": uuid.uuid4(),
+        "user_email": "user@example.com",
+        "goal_text": "My Goal",
+        "status": "in-progress",
+        "full_plan_json": "[]",
+    }
+    quest_node = {
+        "id": uuid.uuid4(),
+        "name": "Step 1",
+        "description": "Do something",
+    }
+    mock_session.write_transaction = mocker.MagicMock(return_value=(goal_node, quest_node))
+
+    def override_get_graph_db_session():
+        yield mock_session
+
+    from api.main import app as main_app
+    from api.database import get_graph_db_session as original_get_graph_db_session
+    original_overrides = main_app.dependency_overrides.copy()
+    main_app.dependency_overrides[original_get_graph_db_session] = override_get_graph_db_session
+
+    # Mock current user
+    def override_get_current_user():
+        return User(id=1, email="user@example.com", is_active=True)
+    from api.routers.auth import get_current_user as orig_get_current_user
+    main_app.dependency_overrides[orig_get_current_user] = override_get_current_user
+
+    yield
+
+    main_app.dependency_overrides = original_overrides
+
+
+def test_parse_goal_returns_goal_and_quest(mock_dependencies, mocker):
+    sub_task = SubTask(title="Step 1", description="Do something", duration_minutes=10)
+    parsed_goal = ParsedGoal(goal_title="My Goal", sub_tasks=[sub_task])
+
+    class DummyChain:
+        async def ainvoke(self, arg):
+            return parsed_goal
+
+    mocker.patch("api.routers.goals.goal_parser_chain", DummyChain())
+
+    response = client.post("/goals/parse", json={"goal": "My Goal"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "goal" in data and "quest" in data
+    assert data["goal"]["goal_text"] == "My Goal"
+    assert data["quest"]["name"] == "Step 1"


### PR DESCRIPTION
## Summary
- return goal and first quest in the goals parse endpoint
- expose new GoalAndQuest schema
- test that goal parsing returns both objects

## Testing
- `pytest tests/test_goals_parse_api.py::test_parse_goal_returns_goal_and_quest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a807f2680832aa3d3c619cb1936b7